### PR TITLE
DB移行に伴うファイルの変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'turbolinks',   '5.0.1'
 gem 'jbuilder',     '2.7.0'
 
 group :development, :test do
-  gem 'sqlite3', '1.3.13'
+  gem "mysql2", ">= 0.3.18", "< 0.5"
   gem 'byebug',  '9.0.6', platform: :mri
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multi_json (1.13.1)
+    mysql2 (0.4.10)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.8.2)
@@ -179,7 +180,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -214,6 +214,7 @@ DEPENDENCIES
   listen (= 3.1.5)
   minitest (~> 5.10, != 5.10.2)
   minitest-reporters (= 1.1.14)
+  mysql2 (>= 0.3.18, < 0.5)
   pg (= 0.20.0)
   puma (= 3.9.1)
   rails (= 5.1.4)
@@ -221,7 +222,6 @@ DEPENDENCIES
   sass-rails (= 5.0.6)
   spring (= 2.0.2)
   spring-watcher-listen (= 2.0.1)
-  sqlite3 (= 1.3.13)
   turbolinks (= 5.0.1)
   tzinfo-data
   uglifier (= 3.2.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,21 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  url: <%= ENV['DATABASE_URL'] || 'mysql2://root@127.0.0.1:3306' %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: sample_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: sample_development
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: sample_development

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20180529111058) do
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  db:
+    image: mysql:5.7
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --innodb-large-prefix=true --innodb-file-format=Barracuda
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - "3306:3306"


### PR DESCRIPTION
Cloud9からローカル環境に移行し、DBを変更した。
RailsTutorialはデフォルトでSQlite3を使うので、ローカルではKehiアプリを参考にMySQL2をDockerで動かせるように設定をした。